### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'buku==4.1',
-    'requests==2.21.0',
+    'requests==2.22.0',
     'ConfigArgParse==0.14.0'
 ]
 


### PR DESCRIPTION
Updated requirement of requests from 2.21 to 2.22. 
It is now possible to install poku with pipx install git+https://github......

Otherwise I get a dependancy fail beacsue urllib3 is to new and incompatible